### PR TITLE
알트 스캐너 전체 검색 및 분류 정렬 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,21 +152,13 @@
         </div>
 
         <!-- 트레이딩 설정 & 스캔 범위 -->
-        <div class="grid4" style="margin-bottom:.75rem;">
+        <div class="grid3" style="margin-bottom:.75rem;">
           <div><label class="small">계좌 잔고 (USDT)</label><input id="acctBalance" type="number" min="100" step="50" value="10000"/></div>
           <div><label class="small">거래당 위험 (%)</label><input id="riskPct" type="number" min="0.1" step="0.1" value="1"/></div>
           <div><label class="small">ATR 손절 배수</label><input id="atrSL" type="number" min="0.5" step="0.1" value="1.5"/></div>
-          <div><label class="small">표시할 상위 후보 개수</label><input id="topN" type="number" min="3" step="1" value="12"/></div>
         </div>
 
-        <div class="grid4" style="margin-bottom:.75rem;">
-          <div>
-            <label class="small">전체 종목 스캔 (USDT-M Perp)</label>
-            <div class="flex items-center gap-2">
-              <input id="scanAllToggle" type="checkbox"/>
-              <span class="small">체크 시 프리셋/커스텀 무시</span>
-            </div>
-          </div>
+        <div class="grid3" style="margin-bottom:.75rem;">
           <div><label class="small">최대 스캔 심볼 수 (거래대금 상위)</label><input id="maxScanSymbols" type="number" min="10" step="10" value="80"/></div>
           <div>
             <label class="small">BTC 포함</label>
@@ -184,22 +176,20 @@
           </div>
         </div>
 
-        <div class="grid4" style="margin-bottom:.25rem;">
-          <div>
-            <label class="small">스캔 심볼 프리셋</label>
-            <select id="preset">
-              <option value="core">Core L1/L2 (기본)</option>
-              <option value="majors">Top Majors</option>
-              <option value="meme">Memes</option>
-              <option value="custom">커스텀 (아래 입력)</option>
-            </select>
-          </div>
-          <div style="grid-column: span 3;">
-            <label class="small">커스텀 심볼 (쉼표 구분, 예: ETHUSDT,SOLUSDT,AVAXUSDT)</label>
-            <input id="customSymbols" type="text" placeholder="예: ETHUSDT,SOLUSDT,AVAXUSDT"/>
-          </div>
+        <div class="small muted mb-2">※ USDT-M PERP **거래대금 상위 N개**를 자동 선별 후 분석합니다.</div>
+
+        <div class="flex items-center gap-2 mb-2">
+          <button id="sortScore" class="btn">점수순</button>
+          <button id="sortMajors" class="btn">탑 메이저 우선</button>
+          <button id="sortCore" class="btn">코어 우선</button>
+          <button id="sortMeme" class="btn">밈 우선</button>
+          <select id="tfFilter" class="ml-2" style="max-width:110px;">
+            <option value="all">시간대 전체</option>
+            <option value="15m">15m</option>
+            <option value="1h">1h</option>
+            <option value="4h">4h</option>
+          </select>
         </div>
-        <div class="small muted mb-2">※ “전체 종목 스캔”을 켜면 USDT-M PERP **거래대금 상위 N개**를 자동 선별 후 분석합니다.</div>
 
         <div class="overflow-x-auto">
           <table class="summary-table">
@@ -207,6 +197,7 @@
               <tr>
                 <th>순위</th>
                 <th>심볼</th>
+                <th>분류</th>
                 <th>시간대</th>
                 <th>방향</th>
                 <th>스코어</th>
@@ -300,11 +291,18 @@
     const EMA_FAST = 12, EMA_SLOW = 26, MACD_SIGNAL = 9;
 
     // PRESETS
-    const PRESETS = {
-      core: ['ETHUSDT','SOLUSDT','BNBUSDT','LINKUSDT','AVAXUSDT','OPUSDT','ARBUSDT','NEARUSDT','SUIUSDT','APTUSDT','ATOMUSDT','MATICUSDT'],
-      majors: ['ETHUSDT','SOLUSDT','BNBUSDT','XRPUSDT','DOGEUSDT','ADAUSDT','AVAXUSDT','TRXUSDT','LINKUSDT','DOTUSDT','NEARUSDT','UNIUSDT'],
-      meme: ['DOGEUSDT','SHIBUSDT','PEPEUSDT','FLOKIUSDT','BONKUSDT','WIFUSDT','MEWUSDT','POLYUSDT','LADYSUSDT','BRETTUSDT']
-    };
+      const PRESETS = {
+        core: ['ETHUSDT','SOLUSDT','BNBUSDT','LINKUSDT','AVAXUSDT','OPUSDT','ARBUSDT','NEARUSDT','SUIUSDT','APTUSDT','ATOMUSDT','MATICUSDT'],
+        majors: ['ETHUSDT','SOLUSDT','BNBUSDT','XRPUSDT','DOGEUSDT','ADAUSDT','AVAXUSDT','TRXUSDT','LINKUSDT','DOTUSDT','NEARUSDT','UNIUSDT'],
+        meme: ['DOGEUSDT','SHIBUSDT','PEPEUSDT','FLOKIUSDT','BONKUSDT','WIFUSDT','MEWUSDT','POLYUSDT','LADYSUSDT','BRETTUSDT']
+      };
+
+      function getSymbolCategory(sym){
+        if(PRESETS.majors.includes(sym)) return 'Top Majors';
+        if(PRESETS.meme.includes(sym)) return 'Meme';
+        if(PRESETS.core.includes(sym)) return 'Core';
+        return 'Other';
+      }
 
     // ==============================
     // DOM
@@ -328,26 +326,29 @@
     const expandAllBtn = document.getElementById('expandAll');
     const collapseAllBtn = document.getElementById('collapseAll');
 
-    const runNowBtn = document.getElementById('runNow');
-    const scanBtnTop = document.getElementById('scanBtnTop');
+      const runNowBtn = document.getElementById('runNow');
+      const scanBtnTop = document.getElementById('scanBtnTop');
 
-    const acctBalanceInput = document.getElementById('acctBalance');
-    const riskPctInput = document.getElementById('riskPct');
-    const atrSLInput = document.getElementById('atrSL');
-    const topNInput = document.getElementById('topN');
-    const presetSelect = document.getElementById('preset');
-    const customSymbolsInput = document.getElementById('customSymbols');
+      const acctBalanceInput = document.getElementById('acctBalance');
+      const riskPctInput = document.getElementById('riskPct');
+      const atrSLInput = document.getElementById('atrSL');
+      const maxScanSymbolsInput = document.getElementById('maxScanSymbols');
+      const includeBTCInput = document.getElementById('includeBTC');
 
-    const scanAllToggle = document.getElementById('scanAllToggle');
-    const maxScanSymbolsInput = document.getElementById('maxScanSymbols');
-    const includeBTCInput = document.getElementById('includeBTC');
+      const chartHeightRange = document.getElementById('chartHeightRange');
+      const chartHeightVal = document.getElementById('chartHeightVal');
 
-    const chartHeightRange = document.getElementById('chartHeightRange');
-    const chartHeightVal = document.getElementById('chartHeightVal');
+      const lastAnalyzedAt = document.getElementById('lastAnalyzedAt');
 
-    const lastAnalyzedAt = document.getElementById('lastAnalyzedAt');
+      const altTableBody = document.getElementById('altTableBody');
+      const sortScoreBtn = document.getElementById('sortScore');
+      const sortMajorsBtn = document.getElementById('sortMajors');
+      const sortCoreBtn = document.getElementById('sortCore');
+      const sortMemeBtn = document.getElementById('sortMeme');
+      const tfFilter = document.getElementById('tfFilter');
 
-    const altTableBody = document.getElementById('altTableBody');
+      let scanRows = [];
+      let currentSort = 'score';
 
     const sidebar = document.getElementById('sidebar');
     const sidebarBackdrop = document.getElementById('sidebarBackdrop');
@@ -372,6 +373,13 @@
     function sleep(ms){ return new Promise(r=>setTimeout(r,ms));}
     function clamp(v,min,max){ return Math.max(min,Math.min(max,v));}
     function quantile(arr,q){ if(!arr?.length)return null; const a=[...arr].sort((x,y)=>x-y); const pos=(a.length-1)*q; const base=Math.floor(pos); const rest=pos-base; return a[base+1]!==undefined? a[base]+rest*(a[base+1]-a[base]) : a[base];}
+
+    async function runInBatches(tasks, batchSize=10, delay=50){
+      for(let i=0;i<tasks.length;i+=batchSize){
+        await Promise.all(tasks.slice(i,i+batchSize).map(fn=>fn()));
+        if(delay>0 && i+batchSize<tasks.length) await sleep(delay);
+      }
+    }
 
     async function fetchJson(url, tag=''){
       addApiLog(`GET ${url}`);
@@ -915,113 +923,114 @@
       }
     }
 
-    async function runAltScanner(favorability, BAL, RISK, SLmult){
-      const { longGate, shortGate } = marketGatingFromFavorability(favorability);
-      altTableBody.innerHTML='';
-
-      // 심볼 소스 결정
-      let symbols = [];
-      if(scanAllToggle.checked){
+      async function runAltScanner(favorability, BAL, RISK, SLmult){
+        const { longGate, shortGate } = marketGatingFromFavorability(favorability);
+        altTableBody.innerHTML='';
         const maxN = clamp(parseInt(maxScanSymbolsInput.value)||80, 10, 500);
         const includeBTC = !!includeBTCInput.checked;
-        symbols = await getAllUsdtPerpSymbols(maxN, includeBTC);
+        let symbols = await getAllUsdtPerpSymbols(maxN, includeBTC);
         if(!symbols.length){
           addApiLog('전체 종목 스캔 실패 → 프리셋(core)로 폴백', true);
           symbols = PRESETS.core.slice();
         }
-      } else {
-        const presetVal = presetSelect.value;
-        if(presetVal==='custom'){
-          const txt = (customSymbolsInput.value||'').trim();
-          if(txt) symbols = txt.split(',').map(s=>s.trim().toUpperCase()).filter(Boolean);
-          if(!symbols.length){
-            addApiLog('커스텀 입력이 비어 있음 → 프리셋(core) 사용', true);
-            symbols = PRESETS.core.slice();
+        if(!symbols.length){ addApiLog('스캔할 심볼이 없습니다.', true); showError('스캔할 심볼이 없습니다.'); return; }
+
+        scanRows = [];
+        const tasks = [];
+        for(const sym of symbols){
+          for(const tf of ALT_INTERVALS){
+            tasks.push(async ()=>{
+              const res = await analyzeAltSymbol(sym, tf);
+              if(!res) return;
+              const m = res.metrics;
+              if(m.distEma20InAtr!==null && m.distEma20InAtr>2.5) return; // 추격매수 방지
+              const category = getSymbolCategory(sym);
+              const longScore = scoreAltSide(m,'LONG', longGate);
+              const shortScore= scoreAltSide(m,'SHORT', shortGate);
+              const side = longScore>=shortScore? 'LONG':'SHORT';
+              const score = Math.max(longScore, shortScore);
+              const entry = m.price;
+              const tpMult = m.adx>=30?3 : (m.adx>=20?2.5:2); // ADX 기반 TP 배수
+              const tp1 = side==='LONG'? (entry + m.atr*tpMult) : (entry - m.atr*tpMult);
+              const sl  = side==='LONG'? (entry - m.atr*SLmult) : (entry + m.atr*SLmult);
+              const rr  = tpMult / SLmult;
+              if(rr<1.2) return; // 낮은 R:R 제외
+              const {qty, lev} = positionSizing(BAL, RISK, m.atr, SLmult, entry);
+              scanRows.push({
+                symbol:sym, category, interval:tf, side, score,
+                price:m.price, atr:m.atr, adx:m.adx, pdi:m.pdi, mdi:m.mdi, rvol:m.rvol, squeeze:m.squeeze,
+                entry, sl, tp1, rr, qty, lev
+              });
+            });
           }
+        }
+
+        await runInBatches(tasks, 10, 50);
+
+        const fundTasks = scanRows.map(row=> async ()=>{
+          const [fund, oi] = await Promise.all([getFunding(row.symbol), getOI(row.symbol)]);
+          row.funding = (fund!==null? `${fund.toFixed(3)}%` : '-');
+          row.oi = (oi!==null? fmt(oi,0): '-');
+        });
+
+        await runInBatches(fundTasks, 10, 50);
+
+        renderAltTable('score');
+      }
+
+      function renderAltTable(sortMode='score'){
+        currentSort = sortMode;
+        const tfVal = tfFilter.value;
+        let rows = scanRows.filter(r=> tfVal==='all' || r.interval===tfVal);
+        if(sortMode==='score'){
+          rows.sort((a,b)=> b.score - a.score);
         } else {
-          symbols = PRESETS[presetVal]||PRESETS.core;
-        }
-      }
-      if(!symbols.length){ addApiLog('스캔할 심볼이 없습니다.', true); showError('스캔할 심볼이 없습니다. 프리셋을 선택하거나 커스텀을 입력해 주세요.'); return; }
-
-      const TOPN = clamp(parseInt(topNInput.value)||12, 3, 50);
-
-      const scanRows=[];
-      for(const sym of symbols){
-        for(const tf of ALT_INTERVALS){
-          const res = await analyzeAltSymbol(sym, tf);
-          if(!res) continue;
-          const m = res.metrics;
-          const longScore = scoreAltSide(m,'LONG', longGate);
-          const shortScore= scoreAltSide(m,'SHORT', shortGate);
-          const side = longScore>=shortScore? 'LONG':'SHORT';
-          const score = Math.max(longScore, shortScore);
-
-          const entry = m.price;
-          const tp1 = side==='LONG'? (entry + m.atr*2) : (entry - m.atr*2);
-          const sl  = side==='LONG'? (entry - m.atr*SLmult) : (entry + m.atr*SLmult);
-          const rr  = (Math.abs(tp1-entry)) / (m.atr*SLmult);
-          const {qty, lev} = positionSizing(BAL, RISK, m.atr, SLmult, entry);
-
-          scanRows.push({
-            symbol:sym, interval:tf, side, score,
-            price:m.price, atr:m.atr, adx:m.adx, pdi:m.pdi, mdi:m.mdi, rvol:m.rvol, squeeze:m.squeeze,
-            entry, sl, tp1, rr, qty, lev
+          const target = sortMode==='majors'? 'Top Majors' : (sortMode==='core'? 'Core' : 'Meme');
+          rows.sort((a,b)=>{
+            const oa = a.category===target?0:1;
+            const ob = b.category===target?0:1;
+            if(oa!==ob) return oa - ob;
+            return b.score - a.score;
           });
-          await sleep(20); // 과호출 방지용 소량 지연
         }
+        altTableBody.innerHTML='';
+        rows.forEach((r, idx)=>{
+          const tr = document.createElement('tr');
+          const clsSide = r.side==='LONG'? 'trend-up':'trend-down';
+          const squeezeTxt = r.squeeze? '✅':'-';
+          const qtyTxt = r.qty? fmt(r.qty,4):'-';
+          const levTxt = r.lev? `${r.lev.toFixed(2)}x`:'-';
+          const note = (r.rr>=1.3? '👍 R:R 양호':'') + (r.adx>=25? ' / ADX↑':'') + (r.rvol>=1.5? ' / RVOL↑':'');
+          tr.innerHTML = `
+            <td>${idx+1}</td>
+            <td>${r.symbol}</td>
+            <td>${r.category}</td>
+            <td>${r.interval}</td>
+            <td class="${clsSide}">${r.side}</td>
+            <td><b>${r.score.toFixed(0)}</b></td>
+            <td>${fmt(r.price,4)}</td>
+            <td>${fmt(r.atr,4)}</td>
+            <td>${fmt(r.adx,1)}</td>
+            <td>${r.pdi!=null? fmt(r.pdi,1): '-'}</td>
+            <td>${r.mdi!=null? fmt(r.mdi,1): '-'}</td>
+            <td>${fmt(r.rvol,2)}</td>
+            <td>${squeezeTxt}</td>
+            <td>${fmt(r.entry,4)}</td>
+            <td>${fmt(r.sl,4)}</td>
+            <td>${fmt(r.tp1,4)}</td>
+            <td>${fmt(r.rr,2)}</td>
+            <td>${qtyTxt}</td>
+            <td>${levTxt}</td>
+            <td>${r.funding||'-'}</td>
+            <td>${r.oi||'-'}</td>
+            <td class="small">${note||'-'}</td>
+          `;
+          altTableBody.appendChild(tr);
+        });
       }
 
-      // 상위 N 표시
-      scanRows.sort((a,b)=> b.score - a.score);
-      const top = scanRows.slice(0, TOPN);
-
-      // 상위 후보에 한해 Funding/OI
-      for(const row of top){
-        const [fund, oi] = await Promise.all([getFunding(row.symbol), getOI(row.symbol)]);
-        row.funding = (fund!==null? `${fund.toFixed(3)}%` : '-');
-        row.oi = (oi!==null? fmt(oi,0): '-');
-        await sleep(10);
-      }
-
-      // 렌더
-      altTableBody.innerHTML='';
-      top.forEach((r, idx)=>{
-        const tr = document.createElement('tr');
-        const clsSide = r.side==='LONG'? 'trend-up':'trend-down';
-        const squeezeTxt = r.squeeze? '✅':'-';
-        const qtyTxt = r.qty? fmt(r.qty,4):'-';
-        const levTxt = r.lev? `${r.lev.toFixed(2)}x`:'-';
-        const note = (r.rr>=1.3? '👍 R:R 양호':'') + (r.adx>=25? ' / ADX↑':'') + (r.rvol>=1.5? ' / RVOL↑':'');
-        tr.innerHTML = `
-          <td>${idx+1}</td>
-          <td>${r.symbol}</td>
-          <td>${r.interval}</td>
-          <td class="${clsSide}">${r.side}</td>
-          <td><b>${r.score.toFixed(0)}</b></td>
-          <td>${fmt(r.price,4)}</td>
-          <td>${fmt(r.atr,4)}</td>
-          <td>${fmt(r.adx,1)}</td>
-          <td>${r.pdi!=null? fmt(r.pdi,1): '-'}</td>
-          <td>${r.mdi!=null? fmt(r.mdi,1): '-'}</td>
-          <td>${fmt(r.rvol,2)}</td>
-          <td>${squeezeTxt}</td>
-          <td>${fmt(r.entry,4)}</td>
-          <td>${fmt(r.sl,4)}</td>
-          <td>${fmt(r.tp1,4)}</td>
-          <td>${fmt(r.rr,2)}</td>
-          <td>${qtyTxt}</td>
-          <td>${levTxt}</td>
-          <td>${r.funding||'-'}</td>
-          <td>${r.oi||'-'}</td>
-          <td class="small">${note||'-'}</td>
-        `;
-        altTableBody.appendChild(tr);
-      });
-    }
-
-    // ==============================
-    // UI 이벤트
+      // ==============================
+      // UI 이벤트
     // ==============================
     function openSidebar(){ sidebar.classList.add('open'); sidebarBackdrop.classList.add('show'); }
     function closeSidebar(){ sidebar.classList.remove('open'); sidebarBackdrop.classList.remove('show'); }
@@ -1054,34 +1063,28 @@
       detailedReasoningContainerDiv.querySelectorAll('details').forEach(d=> d.open = false);
     });
 
-    // 스캔 소스 UI 안내(프리셋/커스텀 비활성화)
-    function updateScanScopeUI(){
-      const disabled = scanAllToggle.checked;
-      presetSelect.disabled = disabled;
-      customSymbolsInput.disabled = disabled || (presetSelect.value!=='custom');
-      presetSelect.style.opacity = disabled? .5: 1;
-      customSymbolsInput.style.opacity = customSymbolsInput.disabled? .5: 1;
-    }
-    scanAllToggle.addEventListener('change', updateScanScopeUI);
-    presetSelect.addEventListener('change', updateScanScopeUI);
+      // 실행 버튼들
+      runNowBtn.addEventListener('click', ()=>performAnalysis());
+      scanBtnTop.addEventListener('click', async ()=>{
+        clearError(); addApiLog('스캐너 단독 실행');
+        const BAL = parseFloat(acctBalanceInput.value)||10000;
+        const RISK = clamp(parseFloat(riskPctInput.value)||1, 0.1, 5);
+        const SLmult = clamp(parseFloat(atrSLInput.value)||1.5, 0.5, 4);
+        // favorability는 최신 분석값이 없을 수 있으니 0으로 실행(시장 게이팅 비활성)
+        await runAltScanner(0, BAL, RISK, SLmult);
+      });
 
-    // 실행 버튼들
-    runNowBtn.addEventListener('click', ()=>performAnalysis());
-    scanBtnTop.addEventListener('click', async ()=>{
-      clearError(); addApiLog('스캐너 단독 실행');
-      const BAL = parseFloat(acctBalanceInput.value)||10000;
-      const RISK = clamp(parseFloat(riskPctInput.value)||1, 0.1, 5);
-      const SLmult = clamp(parseFloat(atrSLInput.value)||1.5, 0.5, 4);
-      // favorability는 최신 분석값이 없을 수 있으니 0으로 실행(시장 게이팅 비활성)
-      await runAltScanner(0, BAL, RISK, SLmult);
-    });
+      sortScoreBtn.addEventListener('click', ()=>renderAltTable('score'));
+      sortMajorsBtn.addEventListener('click', ()=>renderAltTable('majors'));
+      sortCoreBtn.addEventListener('click', ()=>renderAltTable('core'));
+      sortMemeBtn.addEventListener('click', ()=>renderAltTable('meme'));
+      tfFilter.addEventListener('change', ()=>renderAltTable(currentSort));
 
     // 초기화
-    window.onload = ()=>{
-      loadChartHeight();
-      updateScanScopeUI();
-      performAnalysis(); // 자동 갱신 없음: 최초 1회만
-    };
+      window.onload = ()=>{
+        loadChartHeight();
+        performAnalysis(); // 자동 갱신 없음: 최초 1회만
+      };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove preset-based filtering from alt scanner and always analyze the full symbol set
- add category detection and buttons to sort results by score, top majors, core, or meme groups
- dynamically scale take profit to adjust risk-reward based on ADX and skip overextended entries
- allow filtering results by timeframe with a new dropdown
- batch alt analyses and funding/OI lookups to speed up scanning through parallelism

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d821dfd8832bbd3b9132bae34ca6